### PR TITLE
feat(body-line-length): allow any body line length

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = {
 			'never',
 			[],
 		],
-		"body-max-length": [0, "always"]
+		"body-max-length": [0, "always"],
+		"body-max-line-length": [0, "always"]
 	}
 }


### PR DESCRIPTION
https://commitlint.js.org/reference/rules.html#body-max-line-length

we usually use body to reference ticket numbers or documentation
so it should never complain about a link being too long
